### PR TITLE
Create a 'copy' button to automatically copy the signature element.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "radium": "^0.18.1",
     "react": "^15.4.1",
     "react-bootstrap": "^0.30.7",
+    "react-clipboard.js": "^1.0.1",
     "react-dom": "^15.4.1",
     "react-frame-component": "^0.6.6",
     "react-redux": "^4.4.6",

--- a/src/components/SignaturePreview.js
+++ b/src/components/SignaturePreview.js
@@ -2,7 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { getFormValues } from 'redux-form';
 import Frame from 'react-frame-component';
-import {Panel} from 'react-bootstrap';
+import {Panel, Button} from 'react-bootstrap';
+import ClipboardButton from 'react-clipboard.js';
+import ReactDOMServer from 'react-dom/server'
 
 import Logo from '../../public/logo.jpg';
 
@@ -15,8 +17,18 @@ const Address = (lines) => {
   return  lines.split('|').map((line) => (<div key={line}>{line}</div>))
 };
 
+const Clipboard = ({formValues}) => {
 
-const SignaturePreview = ({formValues}) => {
+    return (
+        <div>
+        <ClipboardButton component="a" button-class="btn" button-style={{color: 'white'}} data-clipboard-target='#copy-me'>
+            Copy
+        </ClipboardButton>
+        </div>
+    )
+}
+
+const Signature = ({formValues}) => {
 
   const {
     fullName,
@@ -27,10 +39,7 @@ const SignaturePreview = ({formValues}) => {
     location
   } = formValues;
 
-  return (
-    <Panel bsStyle="primary" header="Signature" style={{height: '540px'}}>
-      <div style={ { width: "100%" } }>
-        <Frame style={ { width: "100%", height: 280 } }>
+    return (
           <div style={ { fontSize: 'small' } }>
             <div>
               <b>{ fullName }</b>
@@ -64,11 +73,21 @@ const SignaturePreview = ({formValues}) => {
               </div>
             </div>
           </div>
-        </Frame>
-      </div>
+        );
+}
+
+const SignaturePreview = (state) => {
+
+  return (
+      <Panel bsStyle="primary" header={<Clipboard formValues={state.formValues}/>} style={{height: '540px'}}>
+        
+        <div id='copy-me' >
+            <Signature {...state} />
+        </div>
     </Panel>
     );
 };
+
 
 const mapStateToProps = (state) => {
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1203,6 +1203,14 @@ cli-width@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
 
+clipboard@^1.4.0:
+  version "1.5.16"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.5.16.tgz#916d5e739b0064be61b0b48a535731ecaef3d367"
+  dependencies:
+    good-listener "^1.2.0"
+    select "^1.0.6"
+    tiny-emitter "^1.0.0"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -1605,6 +1613,10 @@ del@^2.0.2:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
+delegate@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.1.1.tgz#22a0e3ea8776c7f89e02d5950942ef9cdfd019cf"
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -2527,6 +2539,12 @@ globby@^5.0.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+good-listener@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.1.tgz#4c5b4681a3e8c91b00f1cb12d89a23b32473547b"
+  dependencies:
+    delegate "^3.1.1"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
@@ -4568,6 +4586,12 @@ react-bootstrap:
     uncontrollable "^4.0.1"
     warning "^3.0.0"
 
+react-clipboard.js:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-clipboard.js/-/react-clipboard.js-1.0.1.tgz#56dea0547c13977cd1a1650fc740e0349aa90bdf"
+  dependencies:
+    clipboard "^1.4.0"
+
 react-dev-utils@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-0.4.2.tgz#ba6fae581fe945a2fc402e9b27c71fda4f62f6a1"
@@ -5029,6 +5053,10 @@ sax@^1.1.4, sax@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
 
+select@^1.0.6:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.0.tgz#a6c520cd9ab919ad81c7d1a273e0452f504dd7a2"
+
 semver@^4.3.1:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
@@ -5442,6 +5470,10 @@ timers-browserify@^2.0.2:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.2.tgz#ab4883cf597dcd50af211349a00fbca56ac86b86"
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-emitter@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-1.1.0.tgz#ab405a21ffed814a76c19739648093d70654fecb"
 
 tmp@~0.0.23:
   version "0.0.31"


### PR DESCRIPTION
Closes #2. 
![dec-14-2016 13-14-58](https://cloud.githubusercontent.com/assets/11598/21201301/5bf925cc-c1ff-11e6-83f3-3c68cf1baa26.gif)

Turns out, we didn't need the iframe. Also, it's hard to access the contents
of the iframe from outside of it, which the 'copy' button needs, so the iframe
is gone.

react-clipboard.js is a wrapper for clipboard.js. It appears to work on mobile
safari. The other clipboard libaries I saw relied on Flash.
One issue is it doesn't look like I can supply custom elements for the copy
button. It only takes a string. The default button is ugly, so I used an anchor
element for the 'button'.

It's a small convenience library and we could probably modify it to take a
custom element.